### PR TITLE
Fix thumb moving issue on touch screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ debug.log
 coverage/**
 dist/
 .vscode
+.idea

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,11 +37,11 @@ gulp.task('build_charting', function () {
 gulp.task('build_charting2', function () {
     var src2 = [
         'source/NationalInstruments/jquery.flot.scattergraph.js',
-        'source/NationalInstruments/jquery.flot.cursors.js',
         'source/NationalInstruments/jquery.thumb.js',
+        'source/NationalInstruments/jquery.flot.cursors.js',
+        'source/NationalInstruments/jquery.flot.axishandle.js',
         'source/NationalInstruments/jquery.flot.parkinglot.js',
         'source/NationalInstruments/jquery.flot.range.cursors.js',
-        'source/NationalInstruments/jquery.flot.axishandle.js',
         'source/NationalInstruments/jquery.flot.intensitygraph.js',
         'dist/source/NationalInstruments/jquery.flot.charting.js',
     ];

--- a/source/NationalInstruments/jquery.flot.axishandle.js
+++ b/source/NationalInstruments/jquery.flot.axishandle.js
@@ -211,7 +211,7 @@ THE SOFTWARE.
             function extractTarget(touchedEl) {
                 let target = touchedEl,
                     elClass = touchedEl.getAttribute('class');
-                if (elClass.includes('thumbIcon') || elClass.includes('thumbLabel')) {
+                if (elClass.includes('interactionLayer')) {
                     target = touchedEl.parentNode;
                     elClass = target.getAttribute('class');
                 }
@@ -463,7 +463,7 @@ THE SOFTWARE.
         function updateThumbsLocation(handle, plot, width, height) {
             if (!handle.thumb) {
                 return;
-            } 
+            }
             const plotOffset = plot.getPlotOffset();
             if (isXAxisHandle(handle)) {
                 const thumbCy = handle.location === 'near'

--- a/source/NationalInstruments/jquery.flot.cursors.js
+++ b/source/NationalInstruments/jquery.flot.cursors.js
@@ -564,7 +564,7 @@ THE SOFTWARE.
             function extractTarget(touchedEl) {
                 var target = touchedEl,
                     elClass = touchedEl.getAttribute('class');
-                if (elClass.includes('thumbIcon') || elClass.includes('thumbLabel')) {
+                if (elClass.includes('interactionLayer')) {
                     target = touchedEl.parentNode;
                     elClass = target.getAttribute('class');
                 }

--- a/source/NationalInstruments/jquery.thumb.js
+++ b/source/NationalInstruments/jquery.thumb.js
@@ -143,6 +143,7 @@ THE SOFTWARE.
             thumbLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text'),
             thumbTextBoundaryBox = document.createElementNS('http://www.w3.org/2000/svg', 'use'),
             thumbGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+            thumbInteractionLayer = document.createElementNS('http://www.w3.org/2000/svg', 'rect'),
             svgLayer = opts.svgRoot,
             radius = opts.size,
             cx = opts.x,
@@ -216,7 +217,7 @@ THE SOFTWARE.
         thumbLabel.setAttributeNS(null, 'lengthAdjust', 'spacingAndGlyphs');
         thumbLabel.setAttribute('class', 'thumbLabel');
         thumbLabel.textContent = opts.abbreviation;
-        thumbLabel.style.pointerEvents = 'all';
+        thumbLabel.style.pointerEvents = 'none';
 
         thumbGroup.appendChild(thumbIcon);
         thumbGroup.appendChild(thumbTextBoundaryBox);
@@ -241,6 +242,18 @@ THE SOFTWARE.
 
         thumbGroup.constraintFunction = opts.constraintFunction;
         svgLayer.appendChild(thumbGroup);
+
+        // thumb interaction layer
+        const bbox = thumbIcon.getBBox();
+        thumbInteractionLayer.setAttributeNS(null, 'width', bbox.width);
+        thumbInteractionLayer.setAttributeNS(null, 'height', bbox.height);
+        thumbInteractionLayer.setAttributeNS(null, 'x', bbox.x);
+        thumbInteractionLayer.setAttributeNS(null, 'y', bbox.y);
+        thumbInteractionLayer.setAttributeNS(null, 'transform', 'translate(' + -radius + ' ' + -radius + ')');
+        thumbInteractionLayer.setAttribute('pointer-events', 'all');
+        thumbInteractionLayer.classList.add('interactionLayer');
+        thumbInteractionLayer.style.fill = 'transparent';
+        thumbGroup.appendChild(thumbInteractionLayer);
 
         // determine where to place the symbol by using the boundarybox
         const boundaryBox = thumbTextBoundaryBox.getBBox();
@@ -383,15 +396,10 @@ THE SOFTWARE.
     }
 
     function extractTarget(evt) {
-        var target = evt.target;
-        var elClass = evt.target.getAttribute('class');
-        if (elClass && elClass.indexOf('thumbIcon') !== -1) {
-            target = evt.target.parentNode;
-            elClass = target.getAttribute('class');
-        }
-        if (elClass && elClass.indexOf('thumbLabel') !== -1) {
-            target = evt.target.parentNode;
-            elClass = target.getAttribute('class');
+        let target = evt.target;
+        let classes = target.getAttribute('class');
+        if (classes && classes.includes('interactionLayer')) {
+            return target.parentNode;
         }
         return target;
     }


### PR DESCRIPTION
In this change I fix two issues:
1. it's very hard to drag a thumb on the touch screen
2. flot plugin build issue: parking lot plugin depends on the cursor plugin and axis handle plugin, so the parking lot should be concatenated after the cursor and axis handle.

Here is the details about the first issue.

What's the problem?
-------------------------
On the touch screen it's very hard to drag a thumb to move constantly.

How to reproduce this issue?
---------------------------------
Use the example for thumb. Hide the text on it. Try to drag the thumb in Android Chrome. 

Why is it happening?
------------------------
Currently both <use> and text element inside the thumb element receive the touchmove event but panning on the <use> element breaks when dragged more than a few pixels. Currently I don't know the reason why panning on the use element doesn't work.
We can only pan the thumb by touching on the text element. Further more if we enable text wrapping for the thumb label, the wrapped text is created using tspan and its pointer event is set to none. Then panning on text element doesn't work either. 

How to fix it?
---------------------
I create a transparent rectangle layer on the use and text element and its size is exactly the same as the use element. All the mouse / touch interaction is on this element. 