### PR TITLE
Constraint cursor in graph basing on thumb center

### DIFF
--- a/examples/NationalInstruments/cursors/example.html
+++ b/examples/NationalInstruments/cursors/example.html
@@ -7,7 +7,7 @@
     <link href="example.css" rel="stylesheet" type="text/css">
     <script type="text/javascript" src="../../../node_modules/jquery/dist/jquery.js"></script>
     <script type="text/javascript" src="../../../node_modules/flot/dist/es5/jquery.flot.js"></script>
-    <script type="text/javascript" src="../../../node_modules/flot-thumb-plugin/dist/es5/jquery.thumb.js"></script>
+    <script type="text/javascript" src="../../../source/NationalInstruments/jquery.thumb.js"></script>
     <script type="text/javascript" src="../../../source/NationalInstruments/jquery.flot.cursors.js"></script>
     <script type="text/javascript" src="../../../node_modules/flot/lib/jquery.event.drag.js"></script>
     <script type="text/javascript" src="../../../node_modules/flot/lib/jquery.mousewheel.js"></script>

--- a/source/NationalInstruments/jquery.flot.cursors.js
+++ b/source/NationalInstruments/jquery.flot.cursors.js
@@ -913,9 +913,9 @@ THE SOFTWARE.
                 thumbCx = cursor.x + plotOffset.left;
                 thumbCy = cursor.showThumbs.indexOf('b') !== -1 ? plot.height() + plotOffset.top + constants.thumbRadius : plotOffset.top - constants.thumbRadius;
                 // cursor uses the default constrain function unless we provide one explicitly
-                constraintFunction = cursor.horizontalThumbConstrain ? cursor.horizontalThumbConstrain : function (mouseX, mouseY, currentX, currentY) {
+                constraintFunction = cursor.horizontalThumbConstrain ? cursor.horizontalThumbConstrain : function (mouseX, mouseY, currentX, currentY, thumbX, thumbY) {
                     var offsetLeft = plot.offset().left,
-                        x = Math.max(offsetLeft, Math.min(mouseX, plot.width() + offsetLeft));
+                        x = Math.max(offsetLeft, Math.min(thumbX, plot.width() + offsetLeft)) - thumbX + mouseX;
                     return [x, currentY];
                 };
 
@@ -932,9 +932,9 @@ THE SOFTWARE.
             if (yAxisThumb(cursor) && !cursor.thumbs[yThumbIndex]) {
                 thumbCx = cursor.showThumbs.indexOf('l') !== -1 ? plotOffset.left - constants.thumbRadius : plotOffset.left + plot.width() + constants.thumbRadius;
                 thumbCy = cursor.y + plotOffset.top;
-                constraintFunction = cursor.verticalThumbConstrain ? cursor.verticalThumbConstrain : function (mouseX, mouseY, currentX, currentY) {
+                constraintFunction = cursor.verticalThumbConstrain ? cursor.verticalThumbConstrain : function (mouseX, mouseY, currentX, currentY, thumbX, thumbY) {
                     var offset = plot.offset(),
-                        y = Math.max(offset.top, Math.min(mouseY, plot.height() + offset.top));
+                        y = Math.max(offset.top, Math.min(thumbY, plot.height() + offset.top)) - thumbY + mouseY;
                     return [currentX, y];
                 };
 

--- a/source/NationalInstruments/jquery.flot.parkinglot.js
+++ b/source/NationalInstruments/jquery.flot.parkinglot.js
@@ -737,7 +737,6 @@ THE SOFTWARE.
         }
 
         _onThumbOutOfRange(event) {
-            console.log('out');
             // for the case where the thumb is off the graph we only need to add it to the docker
             // the parking lot's render method will position thumbs
             const orientation = event.detail.orientation;
@@ -776,7 +775,6 @@ THE SOFTWARE.
         }
 
         _onThumbIntoRange(plot, event) {
-            console.log('into');
             // for the case where thumb goes into the graph, not only we need to delete the thumb from the docker
             // but also we need to update thumb's position
             const orientation = event.detail.orientation;
@@ -914,7 +912,6 @@ THE SOFTWARE.
         static _updateThumbPosition(thumb, x, y) {
             const thumbPositionMatrix = thumb.getCTM();
 
-            console.log('_updateThumbPosition', x, y);
             const matrix = `matrix(${thumbPositionMatrix.a} ${thumbPositionMatrix.b} ${thumbPositionMatrix.c} ${thumbPositionMatrix.d} ${x} ${y})`;
             thumb.setAttribute('transform', matrix);
         };

--- a/source/NationalInstruments/jquery.flot.parkinglot.js
+++ b/source/NationalInstruments/jquery.flot.parkinglot.js
@@ -150,51 +150,51 @@ THE SOFTWARE.
         }
 
         _createThumbConstrain(plot) {
-            const horizontalThumbConstrain = (mouseX, mouseY, previousX, previousY) => {
+            const horizontalThumbConstrain = (mouseX, mouseY, previousX, previousY, thumbX, thumbY) => {
                 const thumb = this.thumbMoveState.selectedElement;
                 const plotOffset = plot.getPlotOffset();
-                let x = mouseX;
+                let thumbPositioned = false;
                 if (this.thumbMoveState.inParkingLot) {
                     const offset = plot.offset();
-                    const mouseInGraph = mouseX >= offset.left && mouseX <= offset.left + plot.width();
-                    if (mouseInGraph) {
+                    const thumbInGraph = thumbX >= offset.left && thumbX <= offset.left + plot.width();
+                    if (thumbInGraph) {
                         $.thumb.setHidden(thumb, false);
-                        const detail = { target: thumb, edge: this.thumbMoveState.parkingLotLocation, orientation: 'horizontal', position: mouseX - offset.left + plotOffset.left };
+                        const detail = { target: thumb, edge: this.thumbMoveState.parkingLotLocation, orientation: 'horizontal', position: thumbX - offset.left + plotOffset.left };
                         if (this.thumbMoveState.axisHandle) {
                             detail.axisHandle = this.thumbMoveState.axisHandle;
                         }
                         this._dispatchThumbEvent('thumbIntoRange', detail, plot.getEventHolder());
-                        x = previousX;
+                        thumbPositioned = true;
                         this.thumbMoveState.inParkingLot = false;
                     }
                 } else {
-                    [this.thumbMoveState.inParkingLot, this.thumbMoveState.parkingLotLocation] = this._willHorizontalThumbBeMovedOffGraph(thumb, mouseX, plot);
+                    [this.thumbMoveState.inParkingLot, this.thumbMoveState.parkingLotLocation] = this._willHorizontalThumbBeMovedOffGraph(thumb, thumbX, plot);
                 }
 
-                return [x, previousY];
+                return [mouseX, previousY, thumbPositioned];
             };
-            const verticalThumbConstrain = (mouseX, mouseY, previousX, previousY) => {
+            const verticalThumbConstrain = (mouseX, mouseY, previousX, previousY, thumbX, thumbY) => {
                 const thumb = this.thumbMoveState.selectedElement;
                 const plotOffset = plot.getPlotOffset();
-                let y = mouseY;
+                let thumbPositioned = false;
                 if (this.thumbMoveState.inParkingLot) {
                     const offset = plot.offset();
-                    const mouseInGraph = mouseY >= offset.top && mouseY <= offset.top + plot.height();
-                    if (mouseInGraph) {
+                    const thumbInGraph = thumbY >= offset.top && thumbY <= offset.top + plot.height();
+                    if (thumbInGraph) {
                         $.thumb.setHidden(thumb, false);
-                        const detail = { target: thumb, edge: this.thumbMoveState.parkingLotLocation, orientation: 'vertical', position: mouseY - offset.top + plotOffset.top };
+                        const detail = { target: thumb, edge: this.thumbMoveState.parkingLotLocation, orientation: 'vertical', position: thumbY - offset.top + plotOffset.top };
                         if (this.thumbMoveState.axisHandle) {
                             detail.axisHandle = this.thumbMoveState.axisHandle;
                         }
                         this._dispatchThumbEvent('thumbIntoRange', detail, plot.getEventHolder());
-                        y = previousY;
+                        thumbPositioned = true;
                         this.thumbMoveState.inParkingLot = false;
                     }
                 } else {
-                    [this.thumbMoveState.inParkingLot, this.thumbMoveState.parkingLotLocation] = this._willVerticalThumbBeMovedOffGraph(thumb, mouseY, plot);
+                    [this.thumbMoveState.inParkingLot, this.thumbMoveState.parkingLotLocation] = this._willVerticalThumbBeMovedOffGraph(thumb, thumbY, plot);
                 }
 
-                return [previousX, y];
+                return [previousX, mouseY, thumbPositioned];
             };
             return {
                 horizontal: horizontalThumbConstrain,
@@ -737,6 +737,7 @@ THE SOFTWARE.
         }
 
         _onThumbOutOfRange(event) {
+            console.log('out');
             // for the case where the thumb is off the graph we only need to add it to the docker
             // the parking lot's render method will position thumbs
             const orientation = event.detail.orientation;
@@ -775,6 +776,7 @@ THE SOFTWARE.
         }
 
         _onThumbIntoRange(plot, event) {
+            console.log('into');
             // for the case where thumb goes into the graph, not only we need to delete the thumb from the docker
             // but also we need to update thumb's position
             const orientation = event.detail.orientation;
@@ -912,6 +914,7 @@ THE SOFTWARE.
         static _updateThumbPosition(thumb, x, y) {
             const thumbPositionMatrix = thumb.getCTM();
 
+            console.log('_updateThumbPosition', x, y);
             const matrix = `matrix(${thumbPositionMatrix.a} ${thumbPositionMatrix.b} ${thumbPositionMatrix.c} ${thumbPositionMatrix.d} ${x} ${y})`;
             thumb.setAttribute('transform', matrix);
         };

--- a/source/NationalInstruments/jquery.thumb.js
+++ b/source/NationalInstruments/jquery.thumb.js
@@ -327,21 +327,25 @@ THE SOFTWARE.
         }
 
         var page = getEventXYPosition(evt),
+            center = { x: page.X - currentState.deltaHandlingX, y: page.Y - currentState.deltaHandlingY },
             target = extractTarget(evt),
             svgRoot = extractSVGFromTarget(target),
-            eventHolder = svgRoot.eventHolder;
+            eventHolder = svgRoot.eventHolder,
+            positionHandled = false;
 
         if (currentState.selectedElement.constraintFunction) {
-            [page.X, page.Y] = currentState.selectedElement.constraintFunction(page.X, page.Y, currentState.x, currentState.y);
+            [page.X, page.Y, positionHandled] = currentState.selectedElement.constraintFunction(page.X, page.Y, currentState.x, currentState.y, center.x, center.y);
         }
 
-        var currentMatrix = currentState.selectedElement.getCTM(),
-            dx = page.X - currentState.x,
-            dy = page.Y - currentState.y;
-
-        currentMatrix.e += dx;
-        currentMatrix.f += dy;
-        currentState.selectedElement.transform.baseVal.getItem(0).setMatrix(currentMatrix);
+        if (!positionHandled) {
+            var currentMatrix = currentState.selectedElement.getCTM(),
+                dx = page.X - currentState.x,
+                dy = page.Y - currentState.y;
+    
+            currentMatrix.e += dx;
+            currentMatrix.f += dy;
+            currentState.selectedElement.transform.baseVal.getItem(0).setMatrix(currentMatrix);
+        }
 
         //update last mouse position
         currentState.x = page.X;

--- a/tests/cursors_interaction.Test.js
+++ b/tests/cursors_interaction.Test.js
@@ -1066,4 +1066,66 @@ describe("Cursors interaction", function () {
             }
         });
     });
+
+    describe('On thumb', function () {
+        it('should keep thumb center on graph edge when drag thumb out of graph', () => {
+            plot = $.plot("#placeholder", [sampledata], {
+                cursors: [
+                    {
+                        name: 'Blue cursor',
+                        color: 'blue',
+                        showThumbs: 't',
+                        position: { relativeX: 0, relativeY: 0 }
+                    },
+                    {
+                        name: 'Red cursor',
+                        color: 'red',
+                        showThumbs: 'r',
+                        position: { relativeX: 0, relativeY: 0 }
+                    }
+                ]
+            });
+            jasmine.clock().tick(20);
+
+            function thumbCenter(thumb) {
+                var rect = thumb.getBoundingClientRect();
+                return {
+                    x: (rect.left + rect.right) / 2,
+                    y: (rect.top + rect.bottom) / 2,
+                };
+            }
+            var graphArea = {
+                left: plot.offset().left,
+                right: plot.offset().left + plot.width(),
+                top: plot.offset().top,
+                bottom: plot.offset().top + plot.height(),
+            };
+
+            var topThumb = plot.getCursors()[0].thumbs[0];
+            simulate.mouseDown(topThumb, 0, 0);
+            
+            simulate.mouseMove(topThumb, plot.width() + 50, 0);
+            jasmine.clock().tick(20);
+            expect(thumbCenter(topThumb).x).toBeCloseTo(graphArea.right, 0);
+            
+            simulate.mouseMove(topThumb, -(plot.width() + 50), 0);
+            jasmine.clock().tick(20);
+            expect(thumbCenter(topThumb).x).toBeCloseTo(graphArea.left, 0);
+            
+            simulate.mouseUp(topThumb, 0, 0);
+            
+            var rightThumb = plot.getCursors()[1].thumbs[0];
+            simulate.mouseDown(rightThumb, 0, 0);
+            
+            simulate.mouseMove(rightThumb, 0, plot.height() + 50);
+            jasmine.clock().tick(20);
+            expect(thumbCenter(rightThumb).y).toBeCloseTo(graphArea.bottom, 0);
+            
+            simulate.mouseMove(rightThumb, 0, -(plot.height() + 50));
+            jasmine.clock().tick(20);
+            expect(thumbCenter(rightThumb).y).toBeCloseTo(graphArea.top, 0);
+            
+            simulate.mouseUp(rightThumb, 0, 0);
+        });
+    });
 });

--- a/tests/parkingLot.Test.js
+++ b/tests/parkingLot.Test.js
@@ -309,7 +309,7 @@ describe('Parking Lot', () => {
             { thumbLocationWord: 'right', edge: 'top', thumbLocation: 'r' },
             { thumbLocationWord: 'right', edge: 'bottom', thumbLocation: 'r' },
         ].forEach((parameter) => {
-            it(`should keep cursor thumb align with cursor line when the cursor thumb on ${parameter.thumbLocationWord} is moved into the graph range from ${parameter.edge}`, () => {
+            it(`should keep cursor thumb aligned with cursor line when the cursor thumb on ${parameter.thumbLocationWord} is moved into the graph range from ${parameter.edge}`, () => {
                 plot = $.plot("#placeholder", [sampleData], {
                     cursors: [
                         {
@@ -389,7 +389,7 @@ describe('Parking Lot', () => {
             { thumbLocationWord: 'right', edge: 'top', thumbLocation: 'r', expectedDocker: 'topRightVerticalDocker' },
             { thumbLocationWord: 'right', edge: 'bottom', thumbLocation: 'r', expectedDocker: 'bottomRightVerticalDocker' },
         ].forEach((parameter) => {
-            it(`should keep cursor thumb align with cursor line until the center of thumb on ${parameter.thumbLocationWord} is moved out of the graph range cross ${parameter.edge} edge`, () => {
+            it(`should keep cursor thumb aligned with cursor line until the center of thumb on ${parameter.thumbLocationWord} is moved out of the graph range cross ${parameter.edge} edge`, () => {
                 plot = $.plot("#placeholder", [sampleData], {
                     cursors: [
                         {

--- a/tests/parkingLot.Test.js
+++ b/tests/parkingLot.Test.js
@@ -413,7 +413,7 @@ describe('Parking Lot', () => {
                 // Since Firefox's element position is a little different, 1px buffer is used for the critical condition
                 switch (parameter.edge) {
                 case 'right':
-                    criticalDelta.x = graphRange.right - thumbInitCenter.x - 2 /* right edge has 1px lefter for thumb moving out */;
+                    criticalDelta.x = graphRange.right - thumbInitCenter.x - 1;
                     secondDelta.x = 2;
                     break;
                 case 'left':

--- a/tests/parkingLot.Test.js
+++ b/tests/parkingLot.Test.js
@@ -347,11 +347,11 @@ describe('Parking Lot', () => {
                     switch (parameter.edge) {
                     case 'right':
                     case 'left':
-                        expect(thumbCenter(thumb).x).toBeCloseTo(cursor.x + plot.offset().left, 0);
+                        expect(thumbCenter(thumb).x - (cursor.x + plot.offset().left)).toBeLessThan(2);
                         break;
                     case 'bottom':
                     case 'top':
-                        expect(thumbCenter(thumb).y).toBeCloseTo(cursor.y + plot.offset().top, 0);
+                        expect(thumbCenter(thumb).y - (cursor.y + plot.offset().top)).toBeLessThan(2);
                         break;
                     }
                 }

--- a/tests/parkingLot.Test.js
+++ b/tests/parkingLot.Test.js
@@ -329,29 +329,29 @@ describe('Parking Lot', () => {
                     thumb = cursor.thumbs[0],
                     graphRange = getGraphRange(plot),
                     delta = { x: 0, y: 0 },
-                    critalDelta = { x: 0, y: 0 }, // The drag delta that almost but not drag the thumb into the range
+                    criticalDelta = { x: 0, y: 0 }, // The drag delta that almost but not drag the thumb into the range
                     secondDelta = { x: 0, y: 0 }, // Continue draging after the thumb gets into the range
                     thumbInitCenter = getElementCenter(thumb);
 
                 switch (parameter.edge) {
                 case 'right':
                     delta.x = graphRange.right - thumbInitCenter.x;
-                    critalDelta.x = delta.x + 1;
+                    criticalDelta.x = delta.x + 1;
                     secondDelta.x = -5;
                     break;
                 case 'left':
                     delta.x = graphRange.left + 1/* left edge has 1px righter for thumb moving in */ - thumbInitCenter.x;
-                    critalDelta.x = delta.x - 1;
+                    criticalDelta.x = delta.x - 1;
                     secondDelta.x = 5;
                     break;
                 case 'bottom':
                     delta.y = graphRange.bottom - thumbInitCenter.y;
-                    critalDelta.y = delta.y + 1;
+                    criticalDelta.y = delta.y + 1;
                     secondDelta.y = -5;
                     break;
                 case 'top':
                     delta.y = graphRange.top - thumbInitCenter.y;
-                    critalDelta.y = delta.y - 1;
+                    criticalDelta.y = delta.y - 1;
                     secondDelta.y = 5;
                     break;
                 }
@@ -363,7 +363,7 @@ describe('Parking Lot', () => {
 
                 simulate.mouseDown(thumb, 0, 0);
 
-                simulate.mouseMove(thumb, critalDelta.x, critalDelta.y);
+                simulate.mouseMove(thumb, criticalDelta.x, criticalDelta.y);
                 jasmine.clock().tick(20);
                 expectThumbInParkingLot();
 
@@ -401,37 +401,38 @@ describe('Parking Lot', () => {
                     }
                 });
                 jasmine.clock().tick(20);
-    
+
                 var cursor = plot.getCursors()[0],
                     thumb = cursor.thumbs[0],
                     parkingLot = plot.getParkingLot(),
                     graphRange = getGraphRange(plot),
-                    critalDelta = { x: 0, y: 0 }, // The drag delta that drag the thumb close to the edge
+                    criticalDelta = { x: 0, y: 0 }, // The drag delta that drag the thumb close to the edge
                     secondDelta = { x: 0, y: 0 }, // The final delta that drag the near-edge thumb out of the range
                     thumbInitCenter = getElementCenter(thumb);
-    
+
+                // Since Firefox's element position is a little different, 1px buffer is used for the critical condition
                 switch (parameter.edge) {
                 case 'right':
-                    critalDelta.x = graphRange.right - thumbInitCenter.x - 2 /* right edge has 1px lefter for thumb moving out */;
+                    criticalDelta.x = graphRange.right - thumbInitCenter.x - 2 /* right edge has 1px lefter for thumb moving out */;
                     secondDelta.x = 2;
                     break;
                 case 'left':
-                    critalDelta.x = graphRange.left - thumbInitCenter.x + 1;
+                    criticalDelta.x = graphRange.left - thumbInitCenter.x + 1;
                     secondDelta.x = -2;
                     break;
                 case 'bottom':
-                    critalDelta.y = graphRange.bottom - thumbInitCenter.y - 1;
+                    criticalDelta.y = graphRange.bottom - thumbInitCenter.y - 1;
                     secondDelta.y = 2;
                     break;
                 case 'top':
-                    critalDelta.y = graphRange.top - thumbInitCenter.y + 1;
+                    criticalDelta.y = graphRange.top - thumbInitCenter.y + 1;
                     secondDelta.y = -2;
                     break;
                 }
 
                 simulate.mouseDown(thumb, 0, 0);
                 
-                simulate.mouseMove(thumb, critalDelta.x, critalDelta.y);
+                simulate.mouseMove(thumb, criticalDelta.x, criticalDelta.y);
                 jasmine.clock().tick(20);
                 expect(parkingLot[`${parameter.expectedDocker}`].size).toBe(0);
                 validateThumbAlignToCursor(plot, thumb, parameter.thumbLocation, cursor);

--- a/tests/parkingLot.Test.js
+++ b/tests/parkingLot.Test.js
@@ -406,26 +406,26 @@ describe('Parking Lot', () => {
                     thumb = cursor.thumbs[0],
                     parkingLot = plot.getParkingLot(),
                     graphRange = getGraphRange(plot),
-                    critalDelta = { x: 0, y: 0 }, // The drag delta that drag the thumb to the edge
-                    secondDelta = { x: 0, y: 0 }, // The final delta that drag the thumb on the edge out of the range
+                    critalDelta = { x: 0, y: 0 }, // The drag delta that drag the thumb close to the edge
+                    secondDelta = { x: 0, y: 0 }, // The final delta that drag the near-edge thumb out of the range
                     thumbInitCenter = getElementCenter(thumb);
     
                 switch (parameter.edge) {
                 case 'right':
-                    critalDelta.x = graphRange.right - thumbInitCenter.x - 1 /* right edge has 1px lefter for thumb moving out */;
-                    secondDelta.x = 1;
+                    critalDelta.x = graphRange.right - thumbInitCenter.x - 2 /* right edge has 1px lefter for thumb moving out */;
+                    secondDelta.x = 2;
                     break;
                 case 'left':
-                    critalDelta.x = graphRange.left - thumbInitCenter.x;
-                    secondDelta.x = -1;
+                    critalDelta.x = graphRange.left - thumbInitCenter.x + 1;
+                    secondDelta.x = -2;
                     break;
                 case 'bottom':
-                    critalDelta.y = graphRange.bottom - thumbInitCenter.y;
-                    secondDelta.y = 1;
+                    critalDelta.y = graphRange.bottom - thumbInitCenter.y - 1;
+                    secondDelta.y = 2;
                     break;
                 case 'top':
-                    critalDelta.y = graphRange.top - thumbInitCenter.y;
-                    secondDelta.y = -1;
+                    critalDelta.y = graphRange.top - thumbInitCenter.y + 1;
+                    secondDelta.y = -2;
                     break;
                 }
 


### PR DESCRIPTION
**Current behavior**
While dragging the thumb of a cursor to the graph edge, the constraint function calculation is basing on mouse point. Which means if the touched point is not the center of the thumb, the little different may lead to issues:
- For cursor without a parking lot, the thumb center may stop on somewhere out-of graph edge, or can not reach the edge.
- For cursor with a parking lot, the thumb is moved to the parking lot when the mouse moves across the graph edge, instead of when the thumb center moves across the edge.

Another issue is when the thumb is moved into graph from a parking lot, the constraint function of parking lot code already handles the thumb position, but the thumb code itself shift the thumb again. It makes the thumb has a litter shift from the cursor until the dragging interaction finished.

**Implementation**
Add two parameters and one return to the constraint function. The parameters are the x and y of the thumb center, who may have a small different from mouse x and y and within the same coordinate system. The constraint functions use them to compare with the graph edges. 
The return tells the dragging handler that if the thumb position is already updated. When it is true, the thumb code will not shift the thumb anymore but still update the cached mouse position correctly.