### PR TITLE
Digital waveform graph adjustments

### DIFF
--- a/source/NationalInstruments/jquery.flot.digitalAxis.js
+++ b/source/NationalInstruments/jquery.flot.digitalAxis.js
@@ -182,7 +182,6 @@ THE SOFTWARE.
         let container = $('<div>', {
             css: {
                 'order': 1,
-                'width': '12px',
                 'display': 'flex',
                 'align-items': 'center',
                 'margin-right': '10px'
@@ -192,6 +191,8 @@ THE SOFTWARE.
         if (html) {
             container.append(html);
         } else {
+            container.css('width', '12px');
+
             let svg = $(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
             svg.css({
                 'width': '100%',

--- a/source/NationalInstruments/jquery.flot.digitalAxis.js
+++ b/source/NationalInstruments/jquery.flot.digitalAxis.js
@@ -69,7 +69,7 @@ THE SOFTWARE.
             };
 
             data.forEach(series => {
-                if (series.digitalWaveform.show) {
+                if (series.digitalWaveform.signal.visible) {
                     let assignedToBus = buses[series.digitalWaveform.signal.bus] !== undefined;
                     let signalElement = createSignalTreeItem(0, 0, series.label, digitalAxis.options.signalSymbol, assignedToBus);
                     let elementWidth = getElementWidth(signalElement);
@@ -83,9 +83,11 @@ THE SOFTWARE.
                 maxWidth = Math.max(maxWidth, elementWidth);
             });
 
-            let relativeMaxWidth = (maxWidth + 10) / placeholder.width();
-            let axisWidth = Math.min(relativeMaxWidth, 0.5);
-            offset.left = placeholder.width() * axisWidth;
+            if (maxWidth > 0) {
+                let relativeMaxWidth = (maxWidth + 10) / placeholder.width();
+                let axisWidth = Math.min(relativeMaxWidth, 0.5);
+                offset.left = placeholder.width() * axisWidth;
+            }
         } else {
             offset.left = placeholder.width() * digitalAxis.options.width;
         }

--- a/source/NationalInstruments/jquery.flot.digitalAxis.js
+++ b/source/NationalInstruments/jquery.flot.digitalAxis.js
@@ -26,21 +26,69 @@ THE SOFTWARE.
     }
 
     function init(plot) {
-        plot.hooks.processOptions.push((plot, options) => {
-            let digitalAxis = getDigitalAxis(plot);
-            if (digitalAxis) {
-                plot.hooks.processOffset.push(processOffset);
-                plot.hooks.draw.push(draw);
-
-                digitalAxis.options.show = false;
-            }
-        });
+        plot.hooks.processOptions.push(processOptions);
     }
 
-    function processOffset(plot, offset) {
-        let width = plot.getPlaceholder().width();
+    function processOptions(plot, options) {
         let digitalAxis = getDigitalAxis(plot);
-        offset.left = width * digitalAxis.options.width;
+        if (digitalAxis) {
+            plot.hooks.processDatapoints.push(processDatapoints);
+            plot.hooks.processOffset.push(processOffset);
+            plot.hooks.draw.push(draw);
+
+            digitalAxis.options.show = false;
+
+            for (let i = 0; i < options.buses.length; i++) {
+                if (!options.buses[i].label) {
+                    options.buses[i].label = `Bus ${i + 1}`;
+                }
+            }
+        }
+    }
+
+    function processDatapoints(plot, series, datapoints) {
+        if (series.digitalWaveform.show && !series.label) {
+            let data = plot.getData();
+            series.label = `Signal ${data.indexOf(series) + 1}`;
+        }
+    }
+    
+    function processOffset(plot, offset) {
+        let placeholder = plot.getPlaceholder();
+        let digitalAxis = getDigitalAxis(plot);
+        if (digitalAxis.options.width === 'automatic') {
+            let data = plot.getData();
+            let buses = plot.getOptions().buses;
+            let maxWidth = 0;
+            let getElementWidth = (element) => {
+                element.css('visibility', 'hidden');
+                placeholder.append(element);
+                let elementWidth = element.outerWidth();
+                element.remove();
+                return elementWidth;
+            };
+
+            data.forEach(series => {
+                if (series.digitalWaveform.show) {
+                    let assignedToBus = buses[series.digitalWaveform.signal.bus] !== undefined;
+                    let signalElement = createSignalTreeItem(0, 0, series.label, digitalAxis.options.signalSymbol, assignedToBus);
+                    let elementWidth = getElementWidth(signalElement);
+                    maxWidth = Math.max(maxWidth, elementWidth);
+                }
+            });
+
+            buses.forEach(bus => {
+                let busElement = createBusTreeItem(0, 0, bus.label, digitalAxis.options.busSymbolCollapsed, false);
+                let elementWidth = getElementWidth(busElement);
+                maxWidth = Math.max(maxWidth, elementWidth);
+            });
+
+            let relativeMaxWidth = (maxWidth + 10) / placeholder.width();
+            let axisWidth = Math.min(relativeMaxWidth, 0.5);
+            offset.left = placeholder.width() * axisWidth;
+        } else {
+            offset.left = placeholder.width() * digitalAxis.options.width;
+        }
     }
 
     function draw(plot, ctx) {
@@ -62,7 +110,7 @@ THE SOFTWARE.
         let digitalAxis = getDigitalAxis(plot);
         let plotOffset = plot.getPlotOffset();
         tree.css({
-            'width': `${digitalAxis.options.width * 100}%`,
+            'width': `${plotOffset.left}px`,
             'position': 'absolute',
             'top': plotOffset.top,
             'bottom': plotOffset.bottom,
@@ -82,9 +130,8 @@ THE SOFTWARE.
                     plot.draw();
                 }
 
-                let busLabel = bus.label || `Bus ${index + 1}`;
                 let symbol = expanded ? digitalAxis.options.busSymbolExpanded : digitalAxis.options.busSymbolCollapsed;
-                let busElement = createBusTreeItem(digitalAxis.p2c(bus.top), digitalAxis.p2c(bus.bottom), busLabel, symbol, expanded, onShowHideSignals);
+                let busElement = createBusTreeItem(digitalAxis.p2c(bus.top), digitalAxis.p2c(bus.bottom), bus.label, symbol, expanded, onShowHideSignals);
                 tree.append(busElement);
 
                 signals.forEach(series => {
@@ -107,9 +154,8 @@ THE SOFTWARE.
 
     function createSignalEntry(tree, series, data, digitalAxis, assignedToBus) {
         let signal = series.digitalWaveform.signal;
-        let signalLabel = series.label || `Signal ${data.indexOf(series) + 1}`;
         let symbol = digitalAxis.options.signalSymbol;
-        let signalElement = createSignalTreeItem(digitalAxis.p2c(signal.top), digitalAxis.p2c(signal.bottom), signalLabel, symbol, assignedToBus);
+        let signalElement = createSignalTreeItem(digitalAxis.p2c(signal.top), digitalAxis.p2c(signal.bottom), series.label, symbol, assignedToBus);
         tree.append(signalElement);
     }
 
@@ -218,7 +264,7 @@ THE SOFTWARE.
 
     let defaultOptions = {
         yaxis: {
-            width: 0.2
+            width: 'automatic'
         }
     };
 

--- a/source/NationalInstruments/jquery.flot.digitalWaveform.js
+++ b/source/NationalInstruments/jquery.flot.digitalWaveform.js
@@ -63,18 +63,16 @@ THE SOFTWARE.
             }
         }
 
-        drawRectCrossX(ctx, x1, x2, y1, y2, color, startX, endX) {
-            const drawSegment = (ctx, x1, x2, y1, y2, startX, endX) => {
+        drawRectCrossX(ctx, x1, x2, x11, x21, y1, y2, color, startX, endX) {
+            const drawSegment = (ctx, x1, x2, x11, x21, y1, y2, startX, endX) => {
                 if (startX) {
-                    let x = x1 + (x2 - x1) * BUS_CROSS_DISTANCE / 2;
                     ctx.moveTo(x1, y1);
-                    ctx.lineTo(x, y2);
+                    ctx.lineTo(x11, y2);
                 } else {
                     ctx.moveTo(x1, y2);
                 }
                 if (endX) {
-                    let x = x1 + (x2 - x1) - (x2 - x1) * BUS_CROSS_DISTANCE / 2;
-                    ctx.lineTo(x, y2);
+                    ctx.lineTo(x21, y2);
                     ctx.lineTo(x2, y1);
                 } else {
                     ctx.lineTo(x2, y2);
@@ -83,8 +81,8 @@ THE SOFTWARE.
 
             ctx.beginPath();
             ctx.strokeStyle = color;
-            drawSegment(ctx, x1, x2, (y1 + y2) / 2, y1, startX, endX);
-            drawSegment(ctx, x1, x2, (y1 + y2) / 2, y2, startX, endX);
+            drawSegment(ctx, x1, x2, x11, x21, (y1 + y2) / 2, y1, startX, endX);
+            drawSegment(ctx, x1, x2, x11, x21, (y1 + y2) / 2, y2, startX, endX);
             ctx.stroke();
         }
     }
@@ -295,6 +293,7 @@ THE SOFTWARE.
 
         _lazyInitialize(plot) {
             if (this._initializeSignalsAndBuses) {
+                this._busTransitionWidth = Number.POSITIVE_INFINITY;
                 plot.getOptions().buses.forEach(bus => {
                     this._initializeBusValues(plot, bus);
                 });
@@ -351,6 +350,7 @@ THE SOFTWARE.
                         samples: samples.map((s, i) => s[indexes[i]])
                     });
                     // search next greater x
+                    let prevx = x;
                     x = indexes.reduce((acc, index, i) => {
                         const nextSample = samples[i][index + 1];
                         if (nextSample !== undefined && nextSample.x < acc) {
@@ -358,6 +358,7 @@ THE SOFTWARE.
                         }
                         return acc;
                     }, Number.POSITIVE_INFINITY);
+                    this._busTransitionWidth = Math.min(this._busTransitionWidth, (x - prevx) * BUS_CROSS_DISTANCE);
                     // increment indexes where next x is still smaller than x
                     indexes.forEach((index, i) => {
                         const nextSample = samples[i][index + 1];
@@ -598,6 +599,8 @@ THE SOFTWARE.
                 if (value && shape && color) {
                     const x1c = axes.xaxis.p2c(x1);
                     const x2c = axes.xaxis.p2c(x2);
+                    const x11c = axes.xaxis.p2c(x1 + this._busTransitionWidth / 2);
+                    const x21c = axes.xaxis.p2c(x2 - this._busTransitionWidth / 2);
                     const lastValue = bus.values[i - 1];
                     const nextValue = bus.values[i + 1];
                     switch (shape) {
@@ -605,7 +608,7 @@ THE SOFTWARE.
                             this.renderer.drawRect(ctx, x1c, x2c, y1c, y2c, color, false, value !== lastValue, value !== nextValue);
                             break;
                         case 'rect_cross_x':
-                            this.renderer.drawRectCrossX(ctx, x1c, x2c, y1c, y2c, color, value !== lastValue, value !== nextValue);
+                            this.renderer.drawRectCrossX(ctx, x1c, x2c, x11c, x21c, y1c, y2c, color, value !== lastValue, value !== nextValue);
                             break;
                     }
                 }
@@ -652,21 +655,21 @@ THE SOFTWARE.
                             ? bus.samples[i + 1].x
                             : bus.samples[i].x + bus.samples[i].x - bus.samples[i - 1].x;
                         if (x1 <= axes.xaxis.max && x2 >= axes.xaxis.min) {
-                            let transitionWidth = (axes.xaxis.p2c(x2) - axes.xaxis.p2c(bus.samples[i].x)) * BUS_CROSS_DISTANCE;
+                            let transitionWidth = this._busTransitionWidth;
                             let x;
                             switch (bus.labelPosition) {
                                 case 'center':
                                     x = axes.xaxis.p2c((x1 + x2) / 2);
                                     break;
                                 case 'left':
-                                    x = axes.xaxis.p2c(x1) + transitionWidth / 2;
+                                    x = axes.xaxis.p2c(x1 + transitionWidth / 2);
                                     break;
                                 case 'right':
-                                    x = axes.xaxis.p2c(x2) - transitionWidth / 2;
+                                    x = axes.xaxis.p2c(x2 - transitionWidth / 2);
                                     break;
                             }
                             let text = this._getFormattedBusValue(bus, value);
-                            let maxWidth = (axes.xaxis.p2c(x2) - axes.xaxis.p2c(x1)) - transitionWidth;
+                            let maxWidth = (axes.xaxis.p2c(x2 - transitionWidth) - axes.xaxis.p2c(x1 + transitionWidth));
                             this._drawText(ctx, x, y, text, maxWidth);
                         }
                         x1 = null;

--- a/source/NationalInstruments/jquery.flot.digitalWaveform.js
+++ b/source/NationalInstruments/jquery.flot.digitalWaveform.js
@@ -423,7 +423,7 @@ THE SOFTWARE.
 
         _adjustSeriesDataRange(plot, series, range) {
             this._lazyInitialize(plot);
-            if (series.digitalWaveform.signal.visible) {
+            if (series.digitalWaveform.show) {
                 if (series.data.length > 1) {
                     let points = series.datapoints.points;
                     let ps = series.datapoints.pointsize;

--- a/tests/flot.digitalAxis.Test.js
+++ b/tests/flot.digitalAxis.Test.js
@@ -24,6 +24,15 @@ describe('A digital axis', function() {
         expect(axis.show).toBe(false);
     });
 
+    it('should calculate plot offset depending on labels', function() {
+        options.buses = [{ label: 'Bus' }];
+        let plot = $.plot(placeholder, [{ data: [0, 1, 0], label: 'Signal' }], options);
+
+        let offset = plot.getPlotOffset();
+        expect(offset.left).toBeGreaterThan(0);
+        expect(offset.left).toBeLessThanOrEqual(placeholder.width() * 0.5);
+    });
+
     it('should add plot offset depending on the width', function() {
         options.yaxis.width = 0.3;
         let plot = $.plot(placeholder, [[0, 1, 0]], options);

--- a/tests/flot.digitalWaveform.Test.js
+++ b/tests/flot.digitalWaveform.Test.js
@@ -108,7 +108,7 @@ describe('A digital waveform', function() {
     });
 
     it('should increment data max of x-axis by last step size of signal', function() {
-        options.buses = [{}, { collapsed: true }, {}];
+        options.buses = [{ collapsed: true }];
         let data = [
             [[5, 0, 1], [10, 1, 0], [13, 0, 2]]
         ];

--- a/tests/flot.digitalWaveform.Test.js
+++ b/tests/flot.digitalWaveform.Test.js
@@ -430,7 +430,7 @@ describe('A digital waveform', function() {
 
         plot.draw();
 
-        expect(renderer.drawRectCrossX).toHaveBeenCalledWith(ctx, jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), '#4da74d', jasmine.any(Boolean), jasmine.any(Boolean));
+        expect(renderer.drawRectCrossX).toHaveBeenCalledWith(ctx, jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), '#4da74d', jasmine.any(Boolean), jasmine.any(Boolean));
     });
 
     it('should draw bus with mixed strengths in yellow', function() {
@@ -448,7 +448,7 @@ describe('A digital waveform', function() {
 
             plot.draw();
 
-            expect(renderer.drawRectCrossX).toHaveBeenCalledWith(ctx, jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), '#edc240', jasmine.any(Boolean), jasmine.any(Boolean));
+            expect(renderer.drawRectCrossX).toHaveBeenCalledWith(ctx, jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), jasmine.any(Number), '#edc240', jasmine.any(Boolean), jasmine.any(Boolean));
         });
     });
 
@@ -487,11 +487,34 @@ describe('A digital waveform', function() {
 
         let bus = plot.getOptions().buses[0];
         expect(renderer.drawRectCrossX.calls.allArgs()).toEqual([
-            [ctx, 0.5, 1, bus.top, bus.bottom, '#4da74d', true, true],
-            [ctx, 1, 1.5, bus.top, bus.bottom, '#4da74d', true, false],
-            [ctx, 1.5, 2, bus.top, bus.bottom, '#4da74d', false, false],
-            [ctx, 2, 2.5, bus.top, bus.bottom, '#4da74d', false, true],
-            [ctx, 2.5, 3, bus.top, bus.bottom, '#4da74d', true, true]
+            [ctx, 0.5, 1, jasmine.any(Number), jasmine.any(Number), bus.top, bus.bottom, '#4da74d', true, true],
+            [ctx, 1, 1.5, jasmine.any(Number), jasmine.any(Number), bus.top, bus.bottom, '#4da74d', true, false],
+            [ctx, 1.5, 2, jasmine.any(Number), jasmine.any(Number), bus.top, bus.bottom, '#4da74d', false, false],
+            [ctx, 2, 2.5, jasmine.any(Number), jasmine.any(Number), bus.top, bus.bottom, '#4da74d', false, true],
+            [ctx, 2.5, 3, jasmine.any(Number), jasmine.any(Number), bus.top, bus.bottom, '#4da74d', true, true]
+        ]);
+    });
+
+    it('should draw bus transitions with a width depending on smallest x step', function() {
+        options.buses = [{ collapsed: true }];
+        let data = [
+            [[0, 0], [2, 1], [4, 1]],
+            [[0, 1], [1, 1], [2, 0], [3, 0]]
+        ];
+        let plot = $.plot(placeholder, data, options);
+        let ctx = setupCanvasToSpyOn(plot);
+        let renderer = plot.getDigitalWaveform().renderer;
+
+        spyOn(renderer, 'drawRectCrossX').and.callThrough();
+
+        plot.draw();
+
+        expect(renderer.drawRectCrossX.calls.allArgs()).toEqual([
+            [ctx, jasmine.any(Number), jasmine.any(Number), 0.05, 0.95, jasmine.any(Number), jasmine.any(Number), jasmine.any(String), jasmine.any(Boolean), jasmine.any(Boolean)],
+            [ctx, jasmine.any(Number), jasmine.any(Number), 1.05, 1.95, jasmine.any(Number), jasmine.any(Number), jasmine.any(String), jasmine.any(Boolean), jasmine.any(Boolean)],
+            [ctx, jasmine.any(Number), jasmine.any(Number), 2.05, 2.95, jasmine.any(Number), jasmine.any(Number), jasmine.any(String), jasmine.any(Boolean), jasmine.any(Boolean)],
+            [ctx, jasmine.any(Number), jasmine.any(Number), 3.05, 3.95, jasmine.any(Number), jasmine.any(Number), jasmine.any(String), jasmine.any(Boolean), jasmine.any(Boolean)],
+            [ctx, jasmine.any(Number), jasmine.any(Number), 4.05, 4.95, jasmine.any(Number), jasmine.any(Number), jasmine.any(String), jasmine.any(Boolean), jasmine.any(Boolean)]
         ]);
     });
 
@@ -783,7 +806,7 @@ describe('A digital waveform', function() {
                 spyOn(ctx, 'moveTo').and.callThrough();
                 spyOn(ctx, 'lineTo').and.callThrough();
 
-                renderer.drawRectCrossX(ctx, 0, 2, 0, 1, '#abc123', true, true);
+                renderer.drawRectCrossX(ctx, 0, 2, 0.1, 1.9, 0, 1, '#abc123', true, true);
 
                 expect(ctx.moveTo.calls.allArgs()).toEqual([[0, 0.5], [0, 0.5]]);
                 expect(ctx.lineTo.calls.allArgs()).toEqual([[0.1, 0], [1.9, 0], [2, 0.5], [0.1, 1], [1.9, 1], [2, 0.5]]);
@@ -793,7 +816,7 @@ describe('A digital waveform', function() {
                 spyOn(ctx, 'moveTo').and.callThrough();
                 spyOn(ctx, 'lineTo').and.callThrough();
 
-                renderer.drawRectCrossX(ctx, 0, 2, 0, 1, '#abc123', true, false);
+                renderer.drawRectCrossX(ctx, 0, 2, 0.1, 1.9, 0, 1, '#abc123', true, false);
 
                 expect(ctx.moveTo.calls.allArgs()).toEqual([[0, 0.5], [0, 0.5]]);
                 expect(ctx.lineTo.calls.allArgs()).toEqual([[0.1, 0], [2, 0], [0.1, 1], [2, 1]]);
@@ -803,7 +826,7 @@ describe('A digital waveform', function() {
                 spyOn(ctx, 'moveTo').and.callThrough();
                 spyOn(ctx, 'lineTo').and.callThrough();
 
-                renderer.drawRectCrossX(ctx, 0, 2, 0, 1, '#abc123', false, true);
+                renderer.drawRectCrossX(ctx, 0, 2, 0.1, 1.9, 0, 1, '#abc123', false, true);
 
                 expect(ctx.moveTo.calls.allArgs()).toEqual([[0, 0], [0, 1]]);
                 expect(ctx.lineTo.calls.allArgs()).toEqual([[1.9, 0], [2, 0.5], [1.9, 1], [2, 0.5]]);


### PR DESCRIPTION
This PR inlcudes
- width of a digital axis can be calculated automatically, depending of the width of signal and bus labels
- width of the transition between two different bus values is now constant for all transitions
- fixes for autoscaling and symbol widths