### PR TITLE
Specify digital axis width as absolute

### DIFF
--- a/source/NationalInstruments/jquery.flot.digitalAxis.js
+++ b/source/NationalInstruments/jquery.flot.digitalAxis.js
@@ -86,11 +86,13 @@ THE SOFTWARE.
             if (maxWidth > 0) {
                 let relativeMaxWidth = (maxWidth + 10) / placeholder.width();
                 let axisWidth = Math.min(relativeMaxWidth, 0.5);
-                offset.left = placeholder.width() * axisWidth;
+                digitalAxis.options.elementWidth = placeholder.width() * axisWidth;
             }
         } else {
-            offset.left = placeholder.width() * digitalAxis.options.width;
+            digitalAxis.options.elementWidth = digitalAxis.options.width;
         }
+
+        offset.left += digitalAxis.options.elementWidth
     }
 
     function draw(plot, ctx) {
@@ -112,7 +114,7 @@ THE SOFTWARE.
         let digitalAxis = getDigitalAxis(plot);
         let plotOffset = plot.getPlotOffset();
         tree.css({
-            'width': `${plotOffset.left}px`,
+            'width': `${digitalAxis.options.elementWidth}px`,
             'position': 'absolute',
             'top': plotOffset.top,
             'bottom': plotOffset.bottom,

--- a/tests/flot.digitalAxis.Test.js
+++ b/tests/flot.digitalAxis.Test.js
@@ -34,11 +34,19 @@ describe('A digital axis', function() {
     });
 
     it('should add plot offset depending on the width', function() {
-        options.yaxis.width = 0.3;
+        options.yaxis.width = 100;
         let plot = $.plot(placeholder, [[0, 1, 0]], options);
 
         let offset = plot.getPlotOffset();
-        expect(offset.left).toBeGreaterThanOrEqual(placeholder.width() * options.yaxis.width);
+        expect(offset.left).toBeGreaterThanOrEqual(100);
+    });
+
+    it('should set width of html element', function() {
+        options.yaxis.width = 100;
+        $.plot(placeholder, [[0, 1, 0]], options);
+
+        let element = placeholder.find('#flot-digital-axis');
+        expect(element.width()).toBe(100);
     });
 
     it('should show signals for each visible signal', function() {


### PR DESCRIPTION
To align the digital axis width with other sizing constraints in flot and ni-webcharts, it should be specified in an absolute way instead of relative.