### PR TITLE
fix tooltip throwing an error if item.dataIndex is NaN

### DIFF
--- a/source/misc/jquery.flot.tooltip.js
+++ b/source/misc/jquery.flot.tooltip.js
@@ -174,7 +174,7 @@
                 }
             };
 
-            if (item) {
+            if (item && !isNaN(item.dataIndex)) {
                 plot.showTooltip(item, that.tooltipOptions.snap ? item : pos);
             } else if (that.plotOptions.series.lines.show && that.tooltipOptions.lines === true) {
                 var maxDistance = that.plotOptions.grid.mouseActiveRadius;


### PR DESCRIPTION
In some cases, tooltip plugin throws the following error:
![image](https://user-images.githubusercontent.com/14980771/66760403-51714080-eea2-11e9-94fb-e2dd9c36ac52.png)

Steps to reproduce:
1. Hover over **first** point in the series
1. Launch a redraw while still hovering
