### PR TITLE
Fix race condition of cursor mouse/drag events.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "eslint": "eslint \"./source/**/*.js\"",
-    "test": "karma start karma.conf.js --browsers=Chrome",
+    "test": "karma start karma.conf.js --single-run",
     "karma": "karma start",
     "build": "gulp build"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "eslint": "eslint \"./source/**/*.js\"",
-    "test": "karma start karma.conf.js --single-run",
+    "test": "karma start karma.conf.js --browsers=Chrome",
     "karma": "karma start",
     "build": "gulp build"
   },

--- a/source/NationalInstruments/jquery.flot.cursors.js
+++ b/source/NationalInstruments/jquery.flot.cursors.js
@@ -61,6 +61,7 @@ THE SOFTWARE.
         const thumbPreviousPositionMap = new Map();
         let plotPositionConstrain;
         let svgRoot;
+        var isDragging = false;
 
         function createCursor(options) {
             const defaultCursor = createDefaultCursor();
@@ -647,6 +648,10 @@ THE SOFTWARE.
         }
 
         function handleCursorMouseOver(e, x, y, pageX, pageY) {
+            if (isDragging) {
+                return;
+            }
+            
             var currentlySelectedCursor = selectedCursor(cursors);
 
             if (currentlySelectedCursor && e.buttons === 0) {
@@ -694,6 +699,7 @@ THE SOFTWARE.
         }
 
         function handleCursorMoveStart(e, x, y, pageX, pageY) {
+            isDragging = true;
             var currentlySelectedCursor = selectedCursor(cursors);
             snapMode = snapModes.xy;
             if (currentlySelectedCursor) {
@@ -751,6 +757,7 @@ THE SOFTWARE.
         }
 
         function handleCursorMoveEnd(e, x, y, pageX, pageY) {
+            isDragging = false;
             var currentlySelectedCursor = selectedCursor(cursors);
 
             if (currentlySelectedCursor) {

--- a/tests/cursors_interaction.Test.js
+++ b/tests/cursors_interaction.Test.js
@@ -746,6 +746,7 @@ describe("Cursors interaction", function () {
 
         var cursor = plot.getCursors()[0];
         expect(cursor.selected).toBe(true);
+        $('.flot-overlay').simulate("flotdragend", options);
     });
 
     describe('Mouse pointer', function () {

--- a/tests/cursors_interaction.Test.js
+++ b/tests/cursors_interaction.Test.js
@@ -718,6 +718,36 @@ describe("Cursors interaction", function () {
         expect(xAxes[0].max).toEqual(xMax);
     });
 
+    it('should not deselect the cursor on mouseMove that occurs after dragStart but before dragEnd', function () {
+        plot = $.plot("#placeholder", [sampledata], {
+            cursors: [
+                {
+                    name: 'Blue cursor',
+                    color: 'blue',
+                    position: { relativeX: 0.5, relativeY: 0.6 },
+                    show: true
+                }
+            ]
+        });
+
+        var plotOffset = plot.getPlotOffset();
+        var cursorX = plotOffset.left + plot.width() * 0.5;
+        var cursorY = plotOffset.top + plot.height() * 0.6;
+
+        var options = { mouseX: cursorX,
+            mouseY: cursorY };
+
+        jasmine.clock().tick(20);
+        var eventHolder = plot.getEventHolder();
+        $('.flot-overlay').simulate("flotdragstart", options);
+        jasmine.clock().tick(20);
+        simulate.mouseMove(eventHolder, cursorX, cursorY);
+        jasmine.clock().tick(20);
+
+        var cursor = plot.getCursors()[0];
+        expect(cursor.selected).toBe(true);
+    });
+
     describe('Mouse pointer', function () {
         it('should change the mouse pointer on mouse over the cursor manipulator', function () {
             plot = $.plot("#placeholder", [sampledata], {

--- a/tests/cursors_interaction.Test.js
+++ b/tests/cursors_interaction.Test.js
@@ -746,7 +746,6 @@ describe("Cursors interaction", function () {
 
         var cursor = plot.getCursors()[0];
         expect(cursor.selected).toBe(true);
-        $('.flot-overlay').simulate("flotdragend", options);
     });
 
     describe('Mouse pointer', function () {


### PR DESCRIPTION
While dragging a cursor it's possible upon release of the mouse for the mouseOver event to occur before the dragEnd event, which will possibly result in the cursor becoming deselected before the dragEnd handler, which is bad.