### PR TITLE
Flot annotations2

### DIFF
--- a/docs/NationalInstruments/flot-annotations.md
+++ b/docs/NationalInstruments/flot-annotations.md
@@ -26,7 +26,9 @@ The plugin supports these options:
             textAlign: 'left',
             arrowLength: 20,
             arrowWidth: 5,
-            padding: 5
+            padding: 5,
+            defaultxaxis: 1,
+            defaultyaxis: 1
         },
     ]
 ```

--- a/docs/NationalInstruments/flot-annotations.md
+++ b/docs/NationalInstruments/flot-annotations.md
@@ -27,8 +27,8 @@ The plugin supports these options:
             arrowLength: 20,
             arrowWidth: 5,
             padding: 5,
-            defaultxaxis: 1,
-            defaultyaxis: 1
+            xaxis: 1,
+            yaxis: 1
         },
     ]
 ```
@@ -67,9 +67,9 @@ The plugin supports these options:
 
 **padding** The padding of the text inside the box
 
-**defaultxaxis** The 1 based index of the x axis which the absolute coordinates are relative to
+**xaxis** The 1 based index of the x axis which the absolute coordinates are relative to
 
-**defaultyaxis** The 1 based index of the y axis which the absolute coordinates are relative to
+**yaxis** The 1 based index of the y axis which the absolute coordinates are relative to
 
 ```
 
@@ -126,8 +126,8 @@ var myFlot = $.plot( $("#graph"), ...,
                 color: '#440056',
                 textAlign: 'center',
                 arrowLength: 50,
-                defaultxaxis: 1,
-                defaultyaxis: 1
+                xaxis: 1,
+                yaxis: 1
             }
         ]
     ]

--- a/docs/NationalInstruments/flot-annotations.md
+++ b/docs/NationalInstruments/flot-annotations.md
@@ -65,6 +65,10 @@ The plugin supports these options:
 
 **padding** The padding of the text inside the box
 
+**defaultxaxis** The 1 based index of the x axis which the absolute coordinates are relative to
+
+**defaultyaxis** The 1 based index of the y axis which the absolute coordinates are relative to
+
 ```
 
 Public Methods and events
@@ -85,6 +89,10 @@ The plugin adds some public methods to the plot:
     remove the specified annotation from the plot. annotationToRemove is an annotation
     reference to one of the annotations obtained with getAnnotations()
 
+* plot.hitTest(x, y)
+
+    Tests which annotations contain the relative coordinates passed in
+    Returns an array of indices of the annotations matched
 
 How to use
 ----------
@@ -112,6 +120,8 @@ var myFlot = $.plot( $("#graph"), ...,
                 color: '#440056',
                 textAlign: 'center',
                 arrowLength: 50,
+                defaultxaxis: 1,
+                defaultyaxis: 1
             }
         ]
     ]

--- a/docs/NationalInstruments/flot-annotations.md
+++ b/docs/NationalInstruments/flot-annotations.md
@@ -96,6 +96,11 @@ The plugin adds some public methods to the plot:
     Tests which annotations contain the relative coordinates passed in
     Returns an array of indices of the annotations matched
 
+* plot.getBounds (index)
+
+    Returns the bounds of the annotation at index in relative coordinates
+    If index is out of bounds returns undefined
+
 How to use
 ----------
 
@@ -117,7 +122,6 @@ var myFlot = $.plot( $("#graph"), ...,
                 borderColor: '#FF0000',
                 borderThickness: 1,
                 backgroundColor: '#009900',
-                lineWidth: 2,
                 font: '12pt',
                 color: '#440056',
                 textAlign: 'center',

--- a/source/NationalInstruments/jquery.flot.annotations.js
+++ b/source/NationalInstruments/jquery.flot.annotations.js
@@ -49,8 +49,8 @@ THE SOFTWARE.
                 arrowLength: 20, // length of callout arrow
                 arrowWidth: 5, // width of callout arrow where it meets the box
                 padding: 5, // padding for text inside box
-                defaultxaxis: 1, // the x axis to use for absolute coordinates
-                defaultyaxis: 1 // the y axis to use for absolute coordinates
+                xaxis: 1, // the x axis to use for absolute coordinates
+                yaxis: 1 // the y axis to use for absolute coordinates
             }
         }
 
@@ -197,7 +197,8 @@ THE SOFTWARE.
         }
 
         _calcOffset(plot, ctx, annotation) {
-            let zeroBasedIndex = annotation.defaultxaxis - 1;
+            let zeroBasedXIndex = annotation.xaxis - 1;
+            let zeroBasedYIndex = annotation.yaxis - 1;
             let offset = {x: 0, y: 0};
             if (!annotation.showArrow) {
                 return offset;
@@ -205,8 +206,8 @@ THE SOFTWARE.
 
             let x = annotation.x;
             let y = annotation.y;
-            let xaxis = plot.getXAxes()[zeroBasedIndex];
-            let yaxis = plot.getYAxes()[zeroBasedIndex];
+            let xaxis = plot.getXAxes()[zeroBasedXIndex];
+            let yaxis = plot.getYAxes()[zeroBasedYIndex];
             let arrowDirn = annotation.arrowDirection;
             if (annotation.location === 'absolute') {
                 x = xaxis.p2c(annotation.x);
@@ -238,7 +239,8 @@ THE SOFTWARE.
         }
 
         _drawArrow(plot, ctx, annotation, offset) {
-            let zeroBasedIndex = annotation.defaultxaxis - 1;
+            let zeroBasedXIndex = annotation.xaxis - 1;
+            let zeroBasedYIndex = annotation.yaxis - 1;
             if (!annotation.showArrow) {
                 return;
             }
@@ -248,8 +250,8 @@ THE SOFTWARE.
             let arrowDirn = annotation.arrowDirection;
             let x = annotation.x;
             let y = annotation.y;
-            let xaxis = plot.getXAxes()[zeroBasedIndex];
-            let yaxis = plot.getYAxes()[zeroBasedIndex];
+            let xaxis = plot.getXAxes()[zeroBasedXIndex];
+            let yaxis = plot.getYAxes()[zeroBasedYIndex];
             if (annotation.location === 'absolute') {
                 x = xaxis.p2c(annotation.x);
                 y = yaxis.p2c(annotation.y);
@@ -352,11 +354,12 @@ THE SOFTWARE.
         }
 
         _calcBounds (plot, ctx, annotation, formattedText, offset) {
-            let zeroBasedIndex = annotation.defaultxaxis - 1;
+            let zeroBasedXIndex = annotation.xaxis - 1;
+            let zeroBasedYIndex = annotation.yaxis - 1;
             let x = annotation.x;
             let y = annotation.y;
-            let xaxis = plot.getXAxes()[zeroBasedIndex];
-            let yaxis = plot.getYAxes()[zeroBasedIndex];
+            let xaxis = plot.getXAxes()[zeroBasedXIndex];
+            let yaxis = plot.getYAxes()[zeroBasedYIndex];
             let arrowDirn = annotation.arrowDirection;
             let lineCount = this._lineCount(formattedText);
             if (annotation.location === 'absolute') {

--- a/source/NationalInstruments/jquery.flot.annotations.js
+++ b/source/NationalInstruments/jquery.flot.annotations.js
@@ -130,7 +130,7 @@ THE SOFTWARE.
 
                 let formattedText = this._annotations[i].contentFormatter(this._annotations[i].label);
                 let offset = this._calcOffset(plot, ctx, this._annotations[i]);
-                let bounds = this._getBox(plot, ctx, this._annotations[i], formattedText, offset);
+                let bounds = this._calcBounds(plot, ctx, this._annotations[i], formattedText, offset);
                 if (absX >= bounds.x &&
                     absX <= (bounds.x + bounds.width) &&
                     absY >= bounds.y &&
@@ -140,6 +140,23 @@ THE SOFTWARE.
             }
 
             return found;
+        }
+
+        getBounds (plot, index) {
+            if (index < 0 || index > this._annotations.length - 1) {
+                return;
+            }
+
+            let annotation = this._annotations[index];
+            let formattedText = annotation.contentFormatter(annotation.label);
+            var ctx = plot.getCanvas().getContext("2d");
+            let offset = this._calcOffset(plot, ctx, annotation);
+            let bounds = this._calcBounds(plot, ctx, annotation, formattedText, offset);
+            bounds.x = bounds.x / plot.width();
+            bounds.y = bounds.y / plot.height();
+            bounds.width = bounds.width / plot.width();
+            bounds.height = bounds.height / plot.height();
+            return bounds;
         }
 
         _drawOverlay(plot, ctx) {
@@ -334,7 +351,7 @@ THE SOFTWARE.
             return lineHeight;
         }
 
-        _getBox (plot, ctx, annotation, formattedText, offset) {
+        _calcBounds (plot, ctx, annotation, formattedText, offset) {
             let zeroBasedIndex = annotation.defaultxaxis - 1;
             let x = annotation.x;
             let y = annotation.y;
@@ -394,7 +411,7 @@ THE SOFTWARE.
         }
 
         _drawBox (plot, ctx, annotation, formattedText, offset) {
-            let box = this._getBox(plot, ctx, annotation, formattedText, offset)
+            let box = this._calcBounds(plot, ctx, annotation, formattedText, offset)
             ctx.save();
             ctx.strokeStyle = annotation.borderColor;
             ctx.fillStyle = annotation.backgroundColor;
@@ -466,6 +483,14 @@ THE SOFTWARE.
             }
 
             return annotations.hitTest(this, x, y);
+        }
+
+        plot.getBounds = function (index) {
+            if (!annotations || !annotations.getAnnotations().length) {
+                return;
+            }
+
+            return annotations.getBounds(this, index);
         }
     }
 

--- a/source/NationalInstruments/jquery.flot.annotations.js
+++ b/source/NationalInstruments/jquery.flot.annotations.js
@@ -77,8 +77,8 @@ THE SOFTWARE.
         }
 
         _processOptions(options) {
-            if (options.series && options.series.annotations) {
-                options.series.annotations.forEach((options) => {
+            if (options && options.annotations) {
+                options.annotations.forEach((options) => {
                     this.addAnnotation(options, false);
                 });
             }
@@ -452,7 +452,7 @@ THE SOFTWARE.
         let annotations;
 
         plot.hooks.processOptions.push((plot, options) => {
-            if (options.series.annotations) {
+            if (options.annotations) {
                 annotations = new Annotations(plot, options);
             }
         });
@@ -477,7 +477,7 @@ THE SOFTWARE.
             annotations.removeAnnotation(options, true);
         }
 
-        plot.hitTest = function (x, y) {
+        plot.hitTestAnnotations = function (x, y) {
             if (!annotations || !annotations.getAnnotations().length) {
                 return [];
             }
@@ -485,7 +485,7 @@ THE SOFTWARE.
             return annotations.hitTest(this, x, y);
         }
 
-        plot.getBounds = function (index) {
+        plot.getAnnotationBounds = function (index) {
             if (!annotations || !annotations.getAnnotations().length) {
                 return;
             }

--- a/tests/flot.annotations.Test.js
+++ b/tests/flot.annotations.Test.js
@@ -127,7 +127,7 @@ describe('Flot annotations', function () {
         jasmine.clock().tick(20);
         expect(spy1).toHaveBeenCalledTimes(2);
     });
-    fit('should be possible to position the annotation relative to any of the axes when having multiple ones', function () {
+    it('should be possible to position the annotation relative to any of the axes when having multiple ones', function () {
         plot = $.plot(placeholder, [
             { data: d2, xaxis: 1, yaxis: 1 },
             { data: d3, xaxis: 2, yaxis: 2 }

--- a/tests/flot.annotations.Test.js
+++ b/tests/flot.annotations.Test.js
@@ -288,4 +288,42 @@ describe('Flot annotations', function () {
         expect(annotations.length).toEqual(1);
         expect(annotations[0]).toEqual(0);
     });
+    fit('should return the bounds of an annotation using the public api', function () {
+        let annotation1 = {
+            show: true,
+            location: 'absolute',
+            x: 4,
+            y: 8,
+            label: 'hello world2<br>newline',
+            arrowDirection: 'n',
+            showArrow: false
+        };
+        let annotation2 = {
+            show: true,
+            location: 'absolute',
+            x: 7,
+            y: 12,
+            label: 'hello world2<br>newline',
+            arrowDirection: 'n',
+            showArrow: false
+        };
+        plot = $.plot(placeholder, [ d1, d2, d3 ], {
+            series: {
+                lines: { show: true },
+                points: { show: true, symbol: 'square' },
+                annotations: [annotation1, annotation2]
+            }
+        });
+        jasmine.clock().tick(20);
+        var pos1 = plot.p2c({
+            x1: 4,
+            y1: 8
+        });
+
+        var x1 = pos1.left / plot.width();
+        var y1 = pos1.top / plot.height();
+        let bounds = plot.getBounds(0);
+        expect(bounds.x).toEqual(x1 -bounds.width / 2);
+        expect(bounds.y).toEqual(y1 - bounds.height);
+    });
 });

--- a/tests/flot.annotations.Test.js
+++ b/tests/flot.annotations.Test.js
@@ -323,7 +323,7 @@ describe('Flot annotations', function () {
         var x1 = pos1.left / plot.width();
         var y1 = pos1.top / plot.height();
         let bounds = plot.getBounds(0);
-        expect(bounds.x).toEqual(x1 -bounds.width / 2);
-        expect(bounds.y).toEqual(y1 - bounds.height);
+        expect(bounds.x).toBeCloseTo(x1 -bounds.width / 2, 4);
+        expect(bounds.y).toBeCloseTo(y1 - bounds.height, 4);
     });
 });

--- a/tests/flot.annotations.Test.js
+++ b/tests/flot.annotations.Test.js
@@ -142,8 +142,8 @@ describe('Flot annotations', function () {
                     label: 'hello world2<br>newline',
                     arrowDirection: 'n',
                     showArrow: true,
-                    defaultxaxis: 2,
-                    defaultyaxis: 2
+                    xaxis: 2,
+                    yaxis: 2
                 }
             ],
             xaxes: [

--- a/tests/flot.annotations.Test.js
+++ b/tests/flot.annotations.Test.js
@@ -127,7 +127,7 @@ describe('Flot annotations', function () {
         jasmine.clock().tick(20);
         expect(spy1).toHaveBeenCalledTimes(2);
     });
-    it('should be possible to position the annotation relative to any of the axes when having multiple ones', function () {
+    fit('should be possible to position the annotation relative to any of the axes when having multiple ones', function () {
         plot = $.plot(placeholder, [
             { data: d2, xaxis: 1, yaxis: 1 },
             { data: d3, xaxis: 2, yaxis: 2 }
@@ -137,38 +137,65 @@ describe('Flot annotations', function () {
                 {
                     show: true,
                     location: 'absolute',
-                    x: 7,
-                    y: 12,
+                    x: 5,
+                    y: 5,
                     label: 'hello world2<br>newline',
                     arrowDirection: 'n',
-                    showArrow: true,
+                    showArrow: false,
+                    xaxis: 1,
+                    yaxis: 1
+                },
+                {
+                    show: true,
+                    location: 'absolute',
+                    x: 15,
+                    y: 15,
+                    label: 'hello world2<br>newline',
+                    arrowDirection: 'n',
+                    showArrow: false,
                     xaxis: 2,
                     yaxis: 2
                 }
             ],
             xaxes: [
-                { position: 'bottom' },
-                { position: 'top' }
+                { position: 'bottom', minimum: 0, maximum: 10 },
+                { position: 'top', minimum: 10, maximum: 20 }
             ],
             yaxes: [
-                { position: 'left' },
-                { position: 'right' }
+                { position: 'left', minimum: 0, maximum: 10 },
+                { position: 'right', minimum: 10, maximum: 20 }
             ]
         });
 
         jasmine.clock().tick(20);
 
         var pos1 = plot.p2c({
-            x2: 7,
-            y2: 12
+            x1: 5,
+            y1: 5
+        });
+
+        var pos2 = plot.p2c({
+            x2: 15,
+            y2: 15
         });
 
         var expectedX1 = pos1.left;
         var expectedY1 = pos1.top;
+        var expectedX2 = pos2.left;
+        var expectedY2 = pos2.top;
+        ctx = placeholder.find('.flot-overlay')[0].getContext('2d');
         var spy1 = spyOn(ctx, 'fillRect').and.callThrough();
         plot.triggerRedrawOverlay();
         jasmine.clock().tick(20);
-        expect(spy1).not.toHaveBeenCalledWith(expectedX1, expectedY1, jasmine.any(Number), jasmine.any(Number));
+        let bounds = plot.getAnnotationBounds(0);
+        expectedX1 = expectedX1 - (bounds.width  * plot.width()) / 2;
+        expectedY1 = expectedY1 - (bounds.height * plot.height());
+        bounds = plot.getAnnotationBounds(1);
+        expectedX2 = expectedX2 - (bounds.width  * plot.width()) / 2;
+        expectedY2 = expectedY2 - (bounds.height * plot.height());
+        expect(spy1).toHaveBeenCalledTimes(2);
+        expect(spy1).toHaveBeenCalledWith(expectedX1, expectedY1, jasmine.any(Number), jasmine.any(Number));
+        expect(spy1).toHaveBeenCalledWith(expectedX2, expectedY2, jasmine.any(Number), jasmine.any(Number));
     });
     it('should add an annotation using the public api', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
@@ -285,6 +312,7 @@ describe('Flot annotations', function () {
         var x1 = pos1.left / plot.width();
         var y1 = pos1.top / plot.height();
         let annotations = plot.hitTestAnnotations(x1, y1);
+        // the hit test found one annotation at index 0 in the list
         expect(annotations.length).toEqual(1);
         expect(annotations[0]).toEqual(0);
     });

--- a/tests/flot.annotations.Test.js
+++ b/tests/flot.annotations.Test.js
@@ -36,16 +36,16 @@ describe('Flot annotations', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
             series: {
                 lines: { show: true },
-                points: { show: true, symbol: 'square' },
-                annotations: [{
-                    show: true,
-                    x: 0.5,
-                    y: 0.5,
-                    label: 'hello world2<br>newline',
-                    arrowDirection: 'n',
-                    showArrow: true
-                }]
-            }
+                points: { show: true, symbol: 'square' }
+            },
+            annotations: [{
+                show: true,
+                x: 0.5,
+                y: 0.5,
+                label: 'hello world2<br>newline',
+                arrowDirection: 'n',
+                showArrow: true
+            }]
         });
         ctx = placeholder.find('.flot-overlay')[0].getContext('2d');
         var spy1 = spyOn(ctx, 'moveTo').and.callThrough();
@@ -59,16 +59,16 @@ describe('Flot annotations', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
             series: {
                 lines: { show: true },
-                points: { show: true, symbol: 'square' },
-                annotations: [{
-                    show: false,
-                    x: 0.5,
-                    y: 0.5,
-                    label: 'hello world',
-                    arrowDirection: 'n',
-                    showArrow: true
-                }]
-            }
+                points: { show: true, symbol: 'square' }
+            },
+            annotations: [{
+                show: false,
+                x: 0.5,
+                y: 0.5,
+                label: 'hello world',
+                arrowDirection: 'n',
+                showArrow: true
+            }]
         });
         ctx = placeholder.find('.flot-overlay')[0].getContext('2d');
         var spy1 = spyOn(ctx, 'moveTo').and.callThrough();
@@ -87,18 +87,18 @@ describe('Flot annotations', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
             series: {
                 lines: { show: true },
-                points: { show: true, symbol: 'square' },
-                annotations: [{
-                    show: true,
-                    location: 'relative',
-                    x: 0.5,
-                    y: 0.5,
-                    label: 'hello world',
-                    arrowDirection: 'n',
-                    showArrow: true,
-                    contentFormatter: formatter,
-                }]
-            }
+                points: { show: true, symbol: 'square' }
+            },
+            annotations: [{
+                show: true,
+                location: 'relative',
+                x: 0.5,
+                y: 0.5,
+                label: 'hello world',
+                arrowDirection: 'n',
+                showArrow: true,
+                contentFormatter: formatter,
+            }]
         });
         ctx = placeholder.find('.flot-overlay')[0].getContext('2d');
         plot.triggerRedrawOverlay();
@@ -109,17 +109,17 @@ describe('Flot annotations', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
             series: {
                 lines: { show: true },
-                points: { show: true, symbol: 'square' },
-                annotations: [{
-                    show: true,
-                    location: 'relative',
-                    x: 0.5,
-                    y: 0.5,
-                    label: 'hello world2<br>newline',
-                    arrowDirection: 'n',
-                    showArrow: true
-                }]
-            }
+                points: { show: true, symbol: 'square' }
+            },
+            annotations: [{
+                show: true,
+                location: 'relative',
+                x: 0.5,
+                y: 0.5,
+                label: 'hello world2<br>newline',
+                arrowDirection: 'n',
+                showArrow: true
+            }]
         });
         ctx = placeholder.find('.flot-overlay')[0].getContext('2d');
         var spy1 = spyOn(ctx, 'fillText').and.callThrough();
@@ -196,17 +196,17 @@ describe('Flot annotations', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
             series: {
                 lines: { show: true },
-                points: { show: true, symbol: 'square' },
-                annotations: [{
-                    show: true,
-                    location: 'relative',
-                    x: 0.5,
-                    y: 0.5,
-                    label: 'hello world2<br>newline',
-                    arrowDirection: 'n',
-                    showArrow: true
-                }]
-            }
+                points: { show: true, symbol: 'square' }
+            },
+            annotations: [{
+                show: true,
+                location: 'relative',
+                x: 0.5,
+                y: 0.5,
+                label: 'hello world2<br>newline',
+                arrowDirection: 'n',
+                showArrow: true
+            }]
         });
         plot.removeAnnotation({
             show: true,
@@ -236,9 +236,9 @@ describe('Flot annotations', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
             series: {
                 lines: { show: true },
-                points: { show: true, symbol: 'square' },
-                annotations: [annotation]
-            }
+                points: { show: true, symbol: 'square' }
+            },
+            annotations: [annotation]
         });
         jasmine.clock().tick(20);
         let annotations = plot.getAnnotations();
@@ -272,9 +272,9 @@ describe('Flot annotations', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
             series: {
                 lines: { show: true },
-                points: { show: true, symbol: 'square' },
-                annotations: [annotation1, annotation2]
-            }
+                points: { show: true, symbol: 'square' }
+            },
+            annotations: [annotation1, annotation2]
         });
         jasmine.clock().tick(20);
         var pos1 = plot.p2c({
@@ -284,11 +284,11 @@ describe('Flot annotations', function () {
 
         var x1 = pos1.left / plot.width();
         var y1 = pos1.top / plot.height();
-        let annotations = plot.hitTest(x1, y1);
+        let annotations = plot.hitTestAnnotations(x1, y1);
         expect(annotations.length).toEqual(1);
         expect(annotations[0]).toEqual(0);
     });
-    fit('should return the bounds of an annotation using the public api', function () {
+    it('should return the bounds of an annotation using the public api', function () {
         let annotation1 = {
             show: true,
             location: 'absolute',
@@ -310,9 +310,9 @@ describe('Flot annotations', function () {
         plot = $.plot(placeholder, [ d1, d2, d3 ], {
             series: {
                 lines: { show: true },
-                points: { show: true, symbol: 'square' },
-                annotations: [annotation1, annotation2]
-            }
+                points: { show: true, symbol: 'square' }
+            },
+            annotations: [annotation1, annotation2]
         });
         jasmine.clock().tick(20);
         var pos1 = plot.p2c({
@@ -322,7 +322,7 @@ describe('Flot annotations', function () {
 
         var x1 = pos1.left / plot.width();
         var y1 = pos1.top / plot.height();
-        let bounds = plot.getBounds(0);
+        let bounds = plot.getAnnotationBounds(0);
         expect(bounds.x).toBeCloseTo(x1 -bounds.width / 2, 4);
         expect(bounds.y).toBeCloseTo(y1 - bounds.height, 4);
     });


### PR DESCRIPTION
Updated based on wireframes
Added method hitTest = will be used to modify annotation when mouse if over it
Added method getBounds = will be used to create html elements superimposed on the annotation
defaultxaxis & defaultyaxis - absolute coords can be relative to any axis per Brian