### PR TITLE
Ignore NaN values when searching for nearby items in intensity graph

### DIFF
--- a/source/NationalInstruments/jquery.flot.intensitygraph.js
+++ b/source/NationalInstruments/jquery.flot.intensitygraph.js
@@ -189,6 +189,9 @@ THE SOFTWARE.
 
                 for (let x = 0; x < dataWidth; x++) {
                     for (let y = 0; y < dataHeight; y++) {
+                        if (Number.isNaN(seriesData[x][y])) {
+                            continue;
+                        }
                         const rectCenterPixelX = xaxis.p2c(x + 0.5);
                         const rectCenterPixelY = yaxis.p2c(y + 0.5);
                         // This computes the distance to the nearest edge of the rect, or 0 if the point is within the rect

--- a/tests/flot.intensitygraph.Test.js
+++ b/tests/flot.intensitygraph.Test.js
@@ -811,13 +811,12 @@ describe('An Intensity graph', function() {
         });
         plot.draw();
 
-        let ctx = $(placeholder).find('.flot-base').get(0).getContext('2d');
         let seriesFilter = () => true;
-        let nearbyItem1 = plot.findNearbyItem(1*ctx.canvas.width/8, ctx.canvas.height/2, seriesFilter, 1);
+        let nearbyItem1 = plot.findNearbyItem(1 * plot.width() / 8, plot.height() / 2, seriesFilter, 1);
         expect(nearbyItem1.datapoint).toEqual([0, 0, 0]);
-        let nearbyItem2 = plot.findNearbyItem(4*ctx.canvas.width/8, ctx.canvas.height/2, seriesFilter, 1);
+        let nearbyItem2 = plot.findNearbyItem(4 * plot.width() / 8, plot.height() / 2, seriesFilter, 1);
         expect(nearbyItem2.datapoint).toEqual([1, 0, 0.5]);
-        let nearbyItem3 = plot.findNearbyItem(7*ctx.canvas.width/8, ctx.canvas.height/2, seriesFilter, 1);
+        let nearbyItem3 = plot.findNearbyItem(7 * plot.width() / 8, plot.height() / 2, seriesFilter, 1);
         expect(nearbyItem3.datapoint).toEqual([2, 0, 1]);
     });
 
@@ -838,9 +837,8 @@ describe('An Intensity graph', function() {
         });
         plot.draw();
 
-        let ctx = $(placeholder).find('.flot-base').get(0).getContext('2d');
         let seriesFilter = () => true;
-        let nearbyItems = plot.findNearbyItems(3*ctx.canvas.width/8, ctx.canvas.height/2, seriesFilter, 100);
+        let nearbyItems = plot.findNearbyItems(3 * plot.width() / 8, plot.height() / 2, seriesFilter, 100);
         expect(nearbyItems[0].datapoint).toEqual([1, 0, 0.5]);
         expect(nearbyItems[1].datapoint).toEqual([0, 0, 0]);
     });
@@ -862,11 +860,32 @@ describe('An Intensity graph', function() {
         });
         plot.draw();
 
-        let ctx = $(placeholder).find('.flot-base').get(0).getContext('2d');
         let seriesFilter = () => true;
-        let nearbyItem1 = plot.findNearbyItem(ctx.canvas.width * 1.1, ctx.canvas.height/2, seriesFilter, 1);
+        let nearbyItem1 = plot.findNearbyItem(plot.width() * 1.1, plot.height() / 2, seriesFilter, 1);
         expect(nearbyItem1).toBeNull();
-        let nearbyItem2 = plot.findNearbyItem(ctx.canvas.width/2, ctx.canvas.height * 1.1, seriesFilter, 1);
+        let nearbyItem2 = plot.findNearbyItem(plot.width() / 2, plot.height() * 1.1, seriesFilter, 1);
         expect(nearbyItem2).toBeNull();
+    });
+
+    it('should not return nearby item when value is NaN', function () {
+        plot = $.plot(placeholder, [[[0], [NaN], [1]]], {
+            grid: {show: false},
+            xaxis: {show: false},
+            yaxis: {show: false},
+            series: {
+                intensitygraph: {
+                    show: true,
+                    gradient: [
+                        { value: 0, color: 'red' },
+                        { value: 1, color: 'blue' }
+                    ]
+                }
+            }
+        });
+        plot.draw();
+
+        let seriesFilter = () => true;
+        let nearbyItem = plot.findNearbyItem(plot.width() / 2, plot.height() / 2, seriesFilter, 1);
+        expect(nearbyItem).toBeNull();
     });
 });


### PR DESCRIPTION
Also refactored tests to use `plot.width()` instead of the canvas width property, as the latter isn't necessarily the actual size of the element.